### PR TITLE
[Nelson] Added terraform configurations to add raw, error, canonical folders to data s3 buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,28 @@
 module "covid-data-bucket" {
   source = "./modules/s3"
   bucket_name = var.covid_data_bucket_name
-
+  key_name = [var.error_folder_name, var.raw_folder_name, var.canonical_folder_name]
   force_destroy = false
 }
 
 module "bike-bucket" {
   source = "./modules/s3"
-
   bucket_name = var.citi_bike_data_bucket_name
+  key_name = [var.error_folder_name, var.raw_folder_name, var.canonical_folder_name]
   force_destroy = false
 }
 
 module "logging-bucket" {
   source = "./modules/s3"
   bucket_name = var.logging_bucket_name
-
+  key_name = []
   force_destroy = true
 }
 
 module "athena-bucket" {
   source = "./modules/s3"
   bucket_name = var.athena_bucket_name
-
+  key_name = []
   force_destroy = true
 }
 
@@ -174,4 +174,4 @@ module "cloudwatch" {
 //  name = var.name
 //  release_label = var.release_label
 //  subnet_id = module.security.subnet_id
-//} 
+//}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,6 +1,13 @@
-resource "aws_s3_bucket" "create_bucket"{
+resource "aws_s3_bucket" "create_bucket" {
   bucket = var.bucket_name
   acl = "private"
-
   force_destroy = var.force_destroy
+}
+
+resource "aws_s3_bucket_object" "folder" {
+    bucket = var.bucket_name
+    count = length(var.key_name)
+    key = var.key_name[count.index]
+
+    depends_on = [aws_s3_bucket.create_bucket]
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,2 +1,3 @@
 variable "bucket_name" {}
 variable "force_destroy" {}
+variable "key_name" {}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -23,3 +23,7 @@ citi_bike_data_bucket_name = "citi-bike-data-bucket"
 covid_data_bucket_name = "data-mesh-covid-domain"
 logging_bucket_name = "emr-data-mesh-logging-bucket"
 cluster_name = "Airflow"
+
+error_folder_name = "error/"
+raw_folder_name = "raw/"
+canonical_folder_name = "canonical/"

--- a/variables.tf
+++ b/variables.tf
@@ -24,4 +24,8 @@ variable "covid_data_bucket_name" {}
 variable "citi_bike_data_bucket_name" {}
 variable "logging_bucket_name" {}
 
+variable "error_folder_name" {}
+variable "raw_folder_name" {}
+variable "canonical_folder_name" {}
+
 variable "cluster_name" {}


### PR DESCRIPTION
### Setting up the folder resource:
Within the TerraformDataMesh project we define our S3 buckets under:
modules/s3

In modules/s3/main.tf we define the folder resource.  Note that depends_on is used to ensure that the bucket has been created before creating the folder resource.

As we may have multiple folders for a given bucket, the folder resource takes an array as a parameter, and determines the number of folders to create based on the size of the array.

```
resource "aws_s3_bucket" "create_bucket" {
  bucket = var.bucket_name
  acl = "private"
  force_destroy = var.force_destroy
}

resource "aws_s3_bucket_object" "folder" {
    bucket = var.bucket_name
    count = length(var.key_name)
    key = var.key_name[count.index]

    depends_on = [aws_s3_bucket.create_bucket]
}
```


In modules/s3/variables.tf we define to define “key” that will be referenced by the folder resource


### Syntax to create subfolders within S3
The point of entry to create resources in Terraform is in the main.tf, found at root of the project.

```
module "bike-bucket" {
  source = "./modules/s3"
  bucket_name = var.citi_bike_data_bucket_name
  key_name = [var.error_folder_name, var.raw_folder_name, var.canonical_folder_name]
  force_destroy = false
}

module "logging-bucket" {
  source = "./modules/s3"
  bucket_name = var.logging_bucket_name
  key_name = []
  force_destroy = true
}
```

In order to create subfolders we set key_name under a given bucket module to an array with values that will represent folders within the S3 bucket.

In the event you do not want an S3 bucket with a subfolder, set key_name to an empty array.

All variables that are passed to the main.tf are defined by the variables.tf file, and the variables are set in the terraform.tfvars file.  Please note that all files are located on the root of the project.
