### PR TITLE
[Nelson] Added `--no-cache` switch to `docker build` command to build the latest image

### DIFF
--- a/airflow/scripts/build.sh
+++ b/airflow/scripts/build.sh
@@ -1,2 +1,2 @@
-docker build -t airflow .
+docker build -t airflow . --no-cache
 docker tag airflow:latest 150222441608.dkr.ecr.us-east-2.amazonaws.com/airflow:latest

--- a/airflow/scripts/deploy-to-ecr.sh
+++ b/airflow/scripts/deploy-to-ecr.sh
@@ -3,7 +3,7 @@ if [ $# -gt 0 ]; then
   aws_account_location=$1
 
   aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin "${aws_account_location}"
-  docker build -t airflow .
+  docker build -t airflow . --no-cache
   docker tag airflow:latest "${aws_account_location}"/airflow:latest
   docker push "${aws_account_location}"/airflow:latest
 


### PR DESCRIPTION
By adding the `--no-cache` switch to the docker build command the user is able to update any of the airflow python scripts and create a new docker image.