### PR TITLE
[Nelson] Dynamically generating s3 buckets from config file

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,7 @@
+locals {
+  bucket_config_data_yaml = yamldecode(file("./modules/s3/bucket-config.yaml"))
+}
+
 module "vpc" {
   source = "./modules/vpc"
   project_name = var.project_name
@@ -24,11 +28,11 @@ module "ecr" {
 
 module "iam" {
   source = "./modules/iam"
-  athena_bucket_name = module.s3.athena-bucket
-  covid_data_bucket_name = module.s3.covid-data-bucket
+  athena_bucket_name = local.bucket_config_data_yaml.non_source_domain[0].bucket
+  covid_data_bucket_name = local.bucket_config_data_yaml.source_domain[0].bucket
   glue_catalog_id = module.glue.glue_catalog_id
   glue_catalog_name = module.glue.glue_database_name
-  citi_bike_bucket_name = module.s3.bike-bucket
+  citi_bike_bucket_name = local.bucket_config_data_yaml.source_domain[1].bucket
   project_name = var.project_name
   environment = var.environment
   aws_region = var.aws_region
@@ -78,9 +82,6 @@ module "s3" {
   source = "./modules/s3"
   project_name = var.project_name
   environment = var.environment
-  error_folder_name = var.error_folder_name
-  raw_folder_name = var.raw_folder_name
-  canonical_folder_name = var.canonical_folder_name
 }
 
 // module "load_balancer" {

--- a/terraform/modules/s3/bucket-config.yaml
+++ b/terraform/modules/s3/bucket-config.yaml
@@ -1,5 +1,5 @@
 source_domain:
-- bucket: nl-data-mesh-covid-domain
+- bucket: data-mesh-covid-domain
   product:
   - italy/
   - us/
@@ -7,7 +7,7 @@ source_domain:
   - raw/
   - canonical/
   - error/
-- bucket: nl-citi-bike-data-bucket
+- bucket: citi-bike-data-bucket
   product:
   - bike-data/
   folder:
@@ -15,5 +15,5 @@ source_domain:
   - canonical/
   - error/
 non_source_domain:
-- bucket: nl-athena-data-mesh-output-bucket
-- bucket: nl-emr-data-mesh-logging-bucket
+- bucket: athena-data-mesh-output-bucket
+- bucket: emr-data-mesh-logging-bucket

--- a/terraform/modules/s3/bucket-config.yaml
+++ b/terraform/modules/s3/bucket-config.yaml
@@ -1,0 +1,19 @@
+source_domain:
+- bucket: nl-data-mesh-covid-domain
+  product:
+  - italy/
+  - us/
+  folder:
+  - raw/
+  - canonical/
+  - error/
+- bucket: nl-citi-bike-data-bucket
+  product:
+  - bike-data/
+  folder:
+  - raw/
+  - canonical/
+  - error/
+non_source_domain:
+- bucket: nl-athena-data-mesh-output-bucket
+- bucket: nl-emr-data-mesh-logging-bucket

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,57 +1,59 @@
 locals {
-  folder_list = [var.canonical_folder_name, var.raw_folder_name, var.error_folder_name]
+  bucket_config_data_yaml = yamldecode(file("./modules/s3/bucket-config.yaml"))
+
+  source_domain_list = flatten([for source_domain in local.bucket_config_data_yaml.source_domain :
+
+    [for product_name in source_domain.product :
+      [for folder_name in source_domain.folder : {
+          "${source_domain.bucket}-${product_name}-${folder_name}" = {
+          bucket = source_domain.bucket
+          key = "${product_name} ${folder_name}"
+      }}]
+    ]])
+
+  source_domain_config_map = { for item in local.source_domain_list :
+    keys(item)[0] => values(item)[0]
+  }
+
+  non_source_domain_bucket_list = flatten([for bucket_name in local.bucket_config_data_yaml.non_source_domain : {
+      "bucket-${bucket_name.bucket}" = {
+        bucket = bucket_name.bucket
+      }}
+    ])
+
+  source_domain_bucket_list = flatten([for source_domain_bucket_name in local.bucket_config_data_yaml.source_domain : {
+      "bucket-${source_domain_bucket_name.bucket}" = {
+        bucket = source_domain_bucket_name.bucket
+      }
+    }])
+
+  non_source_domain_bucket_list_map = { for item in local.non_source_domain_bucket_list :
+    keys(item)[0] => values(item)[0]
+  }
+
+  source_domain_bucket_list_map = { for item in local.source_domain_bucket_list :
+    keys(item)[0] => values(item)[0]
+  }
+
+  bucket_list_map = merge(local.non_source_domain_bucket_list_map, local.source_domain_bucket_list_map)
 }
 
-resource "aws_s3_bucket" "covid-data-bucket" {
-   bucket = "${var.project_name}-${var.environment}-${var.covid_data_bucket_name}"
-   force_destroy = false
-   tags = {
-    Terraform = "true"
-    Project = var.project_name
-    Environment = var.environment
+resource "aws_s3_bucket" "create_bucket" {
+  for_each = local.bucket_list_map
+    bucket = each.value.bucket
+    force_destroy = false
+    tags = {
+      Terraform = "true"
+      Project = var.project_name
+      Environment = var.environment
    }
- }
-
-resource "aws_s3_bucket_object" "covid-data-folder" {
-  bucket = "${var.project_name}-${var.environment}-${var.covid_data_bucket_name}"
-  count = length(local.folder_list)
-  key = local.folder_list [count.index]
-  depends_on = [aws_s3_bucket.covid-data-bucket]
 }
 
- resource "aws_s3_bucket" "bike-bucket" {
-   bucket = "${var.project_name}-${var.environment}-${var.citi_bike_data_bucket_name}"
-   force_destroy = false
-   tags = {
-     Terraform = "true"
-     Project = var.project_name
-     Environment = var.environment
-   }
- }
+resource "aws_s3_bucket_object" "create_folder" {
+  for_each = local.source_domain_config_map
+    bucket = each.value.bucket
+    key = each.value.key
+    force_destroy = false
 
-resource "aws_s3_bucket_object" "bike-data-folder" {
-  bucket = "${var.project_name}-${var.environment}-${var.citi_bike_data_bucket_name}"
-  count = length(local.folder_list)
-  key = local.folder_list [count.index]
-  depends_on = [aws_s3_bucket.bike-bucket]
-}
-
- resource "aws_s3_bucket" "logging-bucket" {
-   bucket = "${var.project_name}-${var.environment}-${var.logging_bucket_name}"
-   force_destroy = true
-   tags = {
-     Terraform = "true"
-     Project = var.project_name
-     Environment = var.environment
-   }
- }
-
- resource "aws_s3_bucket" "athena-bucket" {
-   bucket = "${var.project_name}-${var.environment}-${var.athena_bucket_name}"
-   force_destroy = true
-   tags = {
-     Terraform = "true"
-     Project = var.project_name
-     Environment = var.environment
-   }
+  depends_on = [aws_s3_bucket.create_bucket]
 }

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,15 +1,16 @@
-output "covid-data-bucket" {
-  value = aws_s3_bucket.covid-data-bucket.bucket
+
+output "source_domain_config_map_result" {
+  value = local.source_domain_config_map
 }
 
-output "bike-bucket" {
-  value = aws_s3_bucket.bike-bucket.bucket
+output "non_source_domain_bucket_list_map_result" {
+  value = local.non_source_domain_bucket_list_map
 }
 
-output "logging-bucket" {
-  value = aws_s3_bucket.logging-bucket.bucket
+output "source_domain_bucket_list_map_result" {
+  value = local.source_domain_bucket_list_map
 }
 
-output "athena-bucket" {
-  value = aws_s3_bucket.athena-bucket.bucket
+output "bucket_list_map_result" {
+  value = local.bucket_list_map
 }

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,17 +1,2 @@
-variable "athena_bucket_name" {
-  default = "athena-data-mesh-output-bucket"
-}
-variable "covid_data_bucket_name" {
-  default = "data-mesh-covid-domain"
-}
-variable "citi_bike_data_bucket_name" {
-  default = "citi-bike-data-bucket"
-}
-variable "logging_bucket_name" {
-  default = "emr-data-mesh-logging-bucket"
-}
 variable "project_name" {}
 variable "environment" {}
-variable "error_folder_name" {}
-variable "raw_folder_name" {}
-variable "canonical_folder_name" {}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -16,8 +16,5 @@ core_instance_count = 1
 
 glue_db_name = "DataMeshCatalogue"
 
-# S3 Buckets
+# EKS
 cluster_name = "Airflow"
-error_folder_name = "error/"
-raw_folder_name = "raw/"
-canonical_folder_name = "canonical/"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,8 +26,4 @@ variable "ingress_cidr_blocks" {}
 
 variable "glue_db_name" {}
 
-variable "error_folder_name" {}
-variable "raw_folder_name" {}
-variable "canonical_folder_name" {}
-
 variable "cluster_name" {}


### PR DESCRIPTION
This PR adds the capability to read infrastructure from a config file and dynamically create AWS resources from Terraform.

Sample config file:
```
source_domain:
- bucket: data-mesh-covid-domain
  product:
  - italy/
  - us/
  folder:
  - raw/
  - canonical/
  - error/
- bucket: citi-bike-data-bucket
  product:
  - bike-data/
  folder:
  - raw/
  - canonical/
  - error/
non_source_domain:
- bucket: athena-data-mesh-output-bucket
- bucket: emr-data-mesh-logging-bucket
```

In order to run Terraform, perform the following:

Steps:
1. `cd terraform`
2. `terraform init`
3. `terraform plan`
4. `terraform apply`
