### PR TITLE
[Nelson] Removed leading empty space between folders

### DIFF
--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -7,7 +7,7 @@ locals {
       [for folder_name in source_domain.folder : {
           "${source_domain.bucket}-${product_name}-${folder_name}" = {
           bucket = source_domain.bucket
-          key = "${product_name} ${folder_name}"
+          key = "${product_name}${folder_name}"
       }}]
     ]])
 


### PR DESCRIPTION
Fix to remove leading empty spaces in the context of s3 bucket sub-folders.